### PR TITLE
fix tcp sack leak add 999-use-nf_ct_helper_log for ssr plus

### DIFF
--- a/package/kernel/kmod-sched-cake/Makefile
+++ b/package/kernel/kmod-sched-cake/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2016 LEDE
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=sched-cake
+PKG_VERSION:=2018-01-07
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://github.com/dtaht/sch_cake
+PKG_SOURCE_VERSION:=568ed96467f41aad37556b0db11fc008e05941e9
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_ID:=$(PKG_SOURCE_VERSION)
+PKG_MAINTAINER:=Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/sched-cake
+  SUBMENU:=Network Support
+  TITLE:=Cake fq_codel derived shaper
+  URL:=https://github.com/dtaht/sch_cake
+  FILES:=$(PKG_BUILD_DIR)/sch_cake.ko
+  VERSION:=$(LINUX_VERSION)-$(LINUX_RELEASE)
+  AUTOLOAD:=$(call AutoLoad,75,sch_cake)
+  DEPENDS:=+kmod-ipt-conntrack
+endef
+
+include $(INCLUDE_DIR)/kernel-defaults.mk
+
+define KernelPackage/sched-cake/description
+  Common Applications Kept Enhanced fq_codel derived shaper
+endef
+
+define Build/Compile
+	$(MAKE) $(KERNEL_MAKEOPTS) SUBDIRS="$(PKG_BUILD_DIR)" modules
+endef
+
+$(eval $(call KernelPackage,sched-cake))

--- a/package/kernel/kmod-sched-cake/patches/001-fix1.patch
+++ b/package/kernel/kmod-sched-cake/patches/001-fix1.patch
@@ -1,0 +1,11 @@
+--- a/sch_cake.c
++++ b/sch_cake.c
+@@ -70,7 +70,7 @@
+ #include <net/netfilter/nf_conntrack.h>
+ #endif
+ 
+-#if (KERNEL_VERSION(4, 4, 11) > LINUX_VERSION_CODE) || ((KERNEL_VERSION(4, 5, 0) <= LINUX_VERSION_CODE) && (KERNEL_VERSION(4, 5, 5) > LINUX_VERSION_CODE))
++#if (KERNEL_VERSION(3, 18, 11) > LINUX_VERSION_CODE) || ((KERNEL_VERSION(4, 5, 0) <= LINUX_VERSION_CODE) && (KERNEL_VERSION(4, 5, 5) > LINUX_VERSION_CODE))
+ #define qdisc_tree_reduce_backlog(_a, _b, _c) qdisc_tree_decrease_qlen(_a, _b)
+ #endif
+ 

--- a/rules.mk
+++ b/rules.mk
@@ -26,6 +26,11 @@ merge=$(subst $(space),,$(1))
 confvar=$(call merge,$(foreach v,$(1),$(if $($(v)),y,n)))
 strip_last=$(patsubst %.$(lastword $(subst .,$(space),$(1))),%,$(1))
 
+paren_left = (
+paren_right = )
+chars_lower = a b c d e f g h i j k l m n o p q r s t u v w x y z
+chars_upper = A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+
 define sep
 
 endef
@@ -36,6 +41,12 @@ define newline
 endef
 
 version_abbrev = $(if $(if $(CHECK),,$(DUMP)),$(1),$(shell printf '%.8s' $(1)))
+
+__tr_list = $(join $(join $(1),$(foreach char,$(1),$(comma))),$(2))
+__tr_head_stripped = $(subst $(space),,$(foreach cv,$(call __tr_list,$(1),$(2)),$$$(paren_left)subst$(cv)$(comma)))
+__tr_head = $(subst $(paren_left)subst,$(paren_left)subst$(space),$(__tr_head_stripped))
+__tr_tail = $(subst $(space),,$(foreach cv,$(1),$(paren_right)))
+__tr_template = $(__tr_head)$$(1)$(__tr_tail)
 
 _SINGLE=export MAKEFLAGS=$(space);
 CFLAGS:=

--- a/target/linux/generic/patches-3.18/900-0-tcp-limit-payload-size-of-sacked-skbs.patch
+++ b/target/linux/generic/patches-3.18/900-0-tcp-limit-payload-size-of-sacked-skbs.patch
@@ -1,0 +1,183 @@
+From ef27e3c531782ec8213108e11e5515f9724303c7 Mon Sep 17 00:00:00 2001
+From: Eric Dumazet <edumazet@google.com>
+Date: Fri, 17 May 2019 17:17:22 -0700
+Subject: tcp: limit payload size of sacked skbs
+
+commit 3b4929f65b0d8249f19a50245cd88ed1a2f78cff upstream.
+
+Jonathan Looney reported that TCP can trigger the following crash
+in tcp_shifted_skb() :
+
+	BUG_ON(tcp_skb_pcount(skb) < pcount);
+
+This can happen if the remote peer has advertized the smallest
+MSS that linux TCP accepts : 48
+
+An skb can hold 17 fragments, and each fragment can hold 32KB
+on x86, or 64KB on PowerPC.
+
+This means that the 16bit witdh of TCP_SKB_CB(skb)->tcp_gso_segs
+can overflow.
+
+Note that tcp_sendmsg() builds skbs with less than 64KB
+of payload, so this problem needs SACK to be enabled.
+SACK blocks allow TCP to coalesce multiple skbs in the retransmit
+queue, thus filling the 17 fragments to maximal capacity.
+
+CVE-2019-11477 -- u16 overflow of TCP_SKB_CB(skb)->tcp_gso_segs
+
+Backport notes, provided by Joao Martins <joao.m.martins@oracle.com>
+
+v4.15 or since commit 737ff314563 ("tcp: use sequence distance to
+detect reordering") had switched from the packet-based FACK tracking and
+switched to sequence-based.
+
+v4.14 and older still have the old logic and hence on
+tcp_skb_shift_data() needs to retain its original logic and have
+@fack_count in sync. In other words, we keep the increment of pcount with
+tcp_skb_pcount(skb) to later used that to update fack_count. To make it
+more explicit we track the new skb that gets incremented to pcount in
+@next_pcount, and we get to avoid the constant invocation of
+tcp_skb_pcount(skb) all together.
+
+Fixes: 832d11c5cd07 ("tcp: Try to restore large SKBs while SACK processing")
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Reviewed-by: Tyler Hicks <tyhicks@canonical.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+[Salvatore Bonaccorso: Adjust for context changes to backport to
+4.9.168]
+[bwh: Backported to 3.16: adjust context]
+Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
+---
+ include/linux/tcp.h   |  3 +++
+ include/net/tcp.h     |  2 ++
+ net/ipv4/tcp.c        |  1 +
+ net/ipv4/tcp_input.c  | 27 ++++++++++++++++++++++-----
+ net/ipv4/tcp_output.c |  4 ++--
+ 5 files changed, 30 insertions(+), 7 deletions(-)
+
+diff --git a/include/linux/tcp.h b/include/linux/tcp.h
+index d7da0cf..b34cbad 100644
+--- a/include/linux/tcp.h
++++ b/include/linux/tcp.h
+@@ -394,4 +394,7 @@ static inline int fastopen_init_queue(struct sock *sk, int backlog)
+ 	return 0;
+ }
+ 
++int tcp_skb_shift(struct sk_buff *to, struct sk_buff *from, int pcount,
++		  int shiftlen);
++
+ #endif	/* _LINUX_TCP_H */
+diff --git a/include/net/tcp.h b/include/net/tcp.h
+index 6f404e9..21c68c2 100644
+--- a/include/net/tcp.h
++++ b/include/net/tcp.h
+@@ -55,6 +55,8 @@ void tcp_time_wait(struct sock *sk, int state, int timeo);
+ 
+ #define MAX_TCP_HEADER	(128 + MAX_HEADER)
+ #define MAX_TCP_OPTION_SPACE 40
++#define TCP_MIN_SND_MSS		48
++#define TCP_MIN_GSO_SIZE	(TCP_MIN_SND_MSS - MAX_TCP_OPTION_SPACE)
+ 
+ /* 
+  * Never offer a window over 32767 without using window scaling. Some
+diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
+index 5fc281b..e16ae42 100644
+--- a/net/ipv4/tcp.c
++++ b/net/ipv4/tcp.c
+@@ -3169,6 +3169,7 @@ void __init tcp_init(void)
+ 	int max_rshare, max_wshare, cnt;
+ 	unsigned int i;
+ 
++	BUILD_BUG_ON(TCP_MIN_SND_MSS <= MAX_TCP_OPTION_SPACE);
+ 	BUILD_BUG_ON(sizeof(struct tcp_skb_cb) > sizeof(skb->cb));
+ 
+ 	percpu_counter_init(&tcp_sockets_allocated, 0);
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index 00ffa3d..e605b1f 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -1302,7 +1302,7 @@ static bool tcp_shifted_skb(struct sock *sk, struct sk_buff *prev,
+ 	TCP_SKB_CB(skb)->seq += shifted;
+ 
+ 	tcp_skb_pcount_add(prev, pcount);
+-	BUG_ON(tcp_skb_pcount(skb) < pcount);
++	WARN_ON_ONCE(tcp_skb_pcount(skb) < pcount);
+ 	tcp_skb_pcount_add(skb, -pcount);
+ 
+ 	/* When we're adding to gso_segs == 1, gso_size will be zero,
+@@ -1362,6 +1362,21 @@ static int skb_can_shift(const struct sk_buff *skb)
+ 	return !skb_headlen(skb) && skb_is_nonlinear(skb);
+ }
+ 
++int tcp_skb_shift(struct sk_buff *to, struct sk_buff *from,
++		  int pcount, int shiftlen)
++{
++	/* TCP min gso_size is 8 bytes (TCP_MIN_GSO_SIZE)
++	 * Since TCP_SKB_CB(skb)->tcp_gso_segs is 16 bits, we need
++	 * to make sure not storing more than 65535 * 8 bytes per skb,
++	 * even if current MSS is bigger.
++	 */
++	if (unlikely(to->len + shiftlen >= 65535 * TCP_MIN_GSO_SIZE))
++		return 0;
++	if (unlikely(tcp_skb_pcount(to) + pcount > 65535))
++		return 0;
++	return skb_shift(to, from, shiftlen);
++}
++
+ /* Try collapsing SACK blocks spanning across multiple skbs to a single
+  * skb.
+  */
+@@ -1373,6 +1388,7 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 	struct sk_buff *prev;
+ 	int mss;
++	int next_pcount;
+ 	int pcount = 0;
+ 	int len;
+ 	int in_sack;
+@@ -1467,7 +1483,7 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 	if (!after(TCP_SKB_CB(skb)->seq + len, tp->snd_una))
+ 		goto fallback;
+ 
+-	if (!skb_shift(prev, skb, len))
++	if (!tcp_skb_shift(prev, skb, pcount, len))
+ 		goto fallback;
+ 	if (!tcp_shifted_skb(sk, skb, state, pcount, len, mss, dup_sack))
+ 		goto out;
+@@ -1486,9 +1502,10 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 		goto out;
+ 
+ 	len = skb->len;
+-	if (skb_shift(prev, skb, len)) {
+-		pcount += tcp_skb_pcount(skb);
+-		tcp_shifted_skb(sk, skb, state, tcp_skb_pcount(skb), len, mss, 0);
++	next_pcount = tcp_skb_pcount(skb);
++	if (tcp_skb_shift(prev, skb, next_pcount, len)) {
++		pcount += next_pcount;
++		tcp_shifted_skb(sk, skb, state, next_pcount, len, mss, 0);
+ 	}
+ 
+ out:
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index 0d7ed41..2a5c993 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1254,8 +1254,8 @@ static inline int __tcp_mtu_to_mss(struct sock *sk, int pmtu)
+ 	mss_now -= icsk->icsk_ext_hdr_len;
+ 
+ 	/* Then reserve room for full set of TCP options and 8 bytes of data */
+-	if (mss_now < 48)
+-		mss_now = 48;
++	if (mss_now < TCP_MIN_SND_MSS)
++		mss_now = TCP_MIN_SND_MSS;
+ 	return mss_now;
+ }
+ 
+-- 
+cgit v1.1

--- a/target/linux/generic/patches-3.18/900-1-tcp-tcp_fragment-should-apply-sane-memory-limits.patch
+++ b/target/linux/generic/patches-3.18/900-1-tcp-tcp_fragment-should-apply-sane-memory-limits.patch
@@ -1,0 +1,83 @@
+From dc97a907bc76b71c08e7e99a5b1b30ef4d5e4a85 Mon Sep 17 00:00:00 2001
+From: Eric Dumazet <edumazet@google.com>
+Date: Sat, 18 May 2019 05:12:05 -0700
+Subject: tcp: tcp_fragment() should apply sane memory limits
+
+commit f070ef2ac66716357066b683fb0baf55f8191a2e upstream.
+
+Jonathan Looney reported that a malicious peer can force a sender
+to fragment its retransmit queue into tiny skbs, inflating memory
+usage and/or overflow 32bit counters.
+
+TCP allows an application to queue up to sk_sndbuf bytes,
+so we need to give some allowance for non malicious splitting
+of retransmit queue.
+
+A new SNMP counter is added to monitor how many times TCP
+did not allow to split an skb if the allowance was exceeded.
+
+Note that this counter might increase in the case applications
+use SO_SNDBUF socket option to lower sk_sndbuf.
+
+CVE-2019-11478 : tcp_fragment, prevent fragmenting a packet when the
+	socket is already using more than half the allowed space
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Acked-by: Yuchung Cheng <ycheng@google.com>
+Reviewed-by: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+[Salvatore Bonaccorso: Adjust context for backport to 4.9.168]
+[bwh: Backported to 3.16: adjust context]
+Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
+---
+ include/uapi/linux/snmp.h | 1 +
+ net/ipv4/proc.c           | 1 +
+ net/ipv4/tcp_output.c     | 5 +++++
+ 3 files changed, 7 insertions(+)
+
+diff --git a/include/uapi/linux/snmp.h b/include/uapi/linux/snmp.h
+index df40137..baa4995 100644
+--- a/include/uapi/linux/snmp.h
++++ b/include/uapi/linux/snmp.h
+@@ -265,6 +265,7 @@ enum
+ 	LINUX_MIB_TCPWANTZEROWINDOWADV,		/* TCPWantZeroWindowAdv */
+ 	LINUX_MIB_TCPSYNRETRANS,		/* TCPSynRetrans */
+ 	LINUX_MIB_TCPORIGDATASENT,		/* TCPOrigDataSent */
++	LINUX_MIB_TCPWQUEUETOOBIG,		/* TCPWqueueTooBig */
+ 	__LINUX_MIB_MAX
+ };
+ 
+diff --git a/net/ipv4/proc.c b/net/ipv4/proc.c
+index ae0af93..14da517 100644
+--- a/net/ipv4/proc.c
++++ b/net/ipv4/proc.c
+@@ -286,6 +286,7 @@ static const struct snmp_mib snmp4_net_list[] = {
+ 	SNMP_MIB_ITEM("TCPWantZeroWindowAdv", LINUX_MIB_TCPWANTZEROWINDOWADV),
+ 	SNMP_MIB_ITEM("TCPSynRetrans", LINUX_MIB_TCPSYNRETRANS),
+ 	SNMP_MIB_ITEM("TCPOrigDataSent", LINUX_MIB_TCPORIGDATASENT),
++	SNMP_MIB_ITEM("TCPWqueueTooBig", LINUX_MIB_TCPWQUEUETOOBIG),
+ 	SNMP_MIB_SENTINEL
+ };
+ 
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index 2a5c993..e760a1a 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1090,6 +1090,11 @@ int tcp_fragment(struct sock *sk, struct sk_buff *skb, u32 len,
+ 	if (nsize < 0)
+ 		nsize = 0;
+ 
++	if (unlikely((sk->sk_wmem_queued >> 1) > sk->sk_sndbuf)) {
++		NET_INC_STATS(sock_net(sk), LINUX_MIB_TCPWQUEUETOOBIG);
++		return -ENOMEM;
++	}
++
+ 	if (skb_unclone(skb, gfp))
+ 		return -ENOMEM;
+ 
+-- 
+cgit v1.1

--- a/target/linux/generic/patches-3.18/900-2-tcp-add-tcp_min_snd_mss-sysctl.patch
+++ b/target/linux/generic/patches-3.18/900-2-tcp-add-tcp_min_snd_mss-sysctl.patch
@@ -1,0 +1,135 @@
+From 6b7e7997ad3505db7de85ff12276fc84659481d3 Mon Sep 17 00:00:00 2001
+From: Eric Dumazet <edumazet@google.com>
+Date: Thu, 6 Jun 2019 09:15:31 -0700
+Subject: tcp: add tcp_min_snd_mss sysctl
+
+commit 5f3e2bf008c2221478101ee72f5cb4654b9fc363 upstream.
+
+Some TCP peers announce a very small MSS option in their SYN and/or
+SYN/ACK messages.
+
+This forces the stack to send packets with a very high network/cpu
+overhead.
+
+Linux has enforced a minimal value of 48. Since this value includes
+the size of TCP options, and that the options can consume up to 40
+bytes, this means that each segment can include only 8 bytes of payload.
+
+In some cases, it can be useful to increase the minimal value
+to a saner value.
+
+We still let the default to 48 (TCP_MIN_SND_MSS), for compatibility
+reasons.
+
+Note that TCP_MAXSEG socket option enforces a minimal value
+of (TCP_MIN_MSS). David Miller increased this minimal value
+in commit c39508d6f118 ("tcp: Make TCP_MAXSEG minimum more correct.")
+from 64 to 88.
+
+We might in the future merge TCP_MIN_SND_MSS and TCP_MIN_MSS.
+
+CVE-2019-11479 -- tcp mss hardcoded to 48
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Suggested-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+[Salvatore Bonaccorso: Backport for context changes in 4.9.168]
+[bwh: Backported to 3.16: Make the sysctl global, consistent with
+ net.ipv4.tcp_base_mss]
+Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
+---
+ Documentation/networking/ip-sysctl.txt |  8 ++++++++
+ include/net/tcp.h                      |  1 +
+ net/ipv4/sysctl_net_ipv4.c             | 11 +++++++++++
+ net/ipv4/tcp_output.c                  |  4 ++--
+ 4 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/networking/ip-sysctl.txt b/Documentation/networking/ip-sysctl.txt
+index 36aa39e..6020d17 100644
+--- a/Documentation/networking/ip-sysctl.txt
++++ b/Documentation/networking/ip-sysctl.txt
+@@ -210,6 +210,14 @@ tcp_base_mss - INTEGER
+ 	Path MTU discovery (MTU probing).  If MTU probing is enabled,
+ 	this is the initial MSS used by the connection.
+ 
++tcp_min_snd_mss - INTEGER
++	TCP SYN and SYNACK messages usually advertise an ADVMSS option,
++	as described in RFC 1122 and RFC 6691.
++	If this ADVMSS option is smaller than tcp_min_snd_mss,
++	it is silently capped to tcp_min_snd_mss.
++
++	Default : 48 (at least 8 bytes of payload per segment)
++
+ tcp_congestion_control - STRING
+ 	Set the congestion control algorithm to be used for new
+ 	connections. The algorithm "reno" is always available, but
+diff --git a/include/net/tcp.h b/include/net/tcp.h
+index 21c68c2..79762b6 100644
+--- a/include/net/tcp.h
++++ b/include/net/tcp.h
+@@ -270,6 +270,7 @@ extern int sysctl_tcp_moderate_rcvbuf;
+ extern int sysctl_tcp_tso_win_divisor;
+ extern int sysctl_tcp_mtu_probing;
+ extern int sysctl_tcp_base_mss;
++extern int sysctl_tcp_min_snd_mss;
+ extern int sysctl_tcp_workaround_signed_windows;
+ extern int sysctl_tcp_slow_start_after_idle;
+ extern int sysctl_tcp_thin_linear_timeouts;
+diff --git a/net/ipv4/sysctl_net_ipv4.c b/net/ipv4/sysctl_net_ipv4.c
+index e1ceafe..fbbb89c 100644
+--- a/net/ipv4/sysctl_net_ipv4.c
++++ b/net/ipv4/sysctl_net_ipv4.c
+@@ -34,6 +34,8 @@ static int tcp_retr1_max = 255;
+ static int ip_local_port_range_min[] = { 1, 1 };
+ static int ip_local_port_range_max[] = { 65535, 65535 };
+ static int tcp_adv_win_scale_min = -31;
++static int tcp_min_snd_mss_min = TCP_MIN_SND_MSS;
++static int tcp_min_snd_mss_max = 65535;
+ static int tcp_adv_win_scale_max = 31;
+ static int ip_ttl_min = 1;
+ static int ip_ttl_max = 255;
+@@ -608,6 +610,15 @@ static struct ctl_table ipv4_table[] = {
+ 		.proc_handler	= proc_dointvec,
+ 	},
+ 	{
++		.procname	= "tcp_min_snd_mss",
++		.data		= &sysctl_tcp_min_snd_mss,
++		.maxlen		= sizeof(int),
++		.mode		= 0644,
++		.proc_handler	= proc_dointvec_minmax,
++		.extra1		= &tcp_min_snd_mss_min,
++		.extra2		= &tcp_min_snd_mss_max,
++	},
++	{
+ 		.procname	= "tcp_workaround_signed_windows",
+ 		.data		= &sysctl_tcp_workaround_signed_windows,
+ 		.maxlen		= sizeof(int),
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index e760a1a..4a64beb 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -61,6 +61,7 @@ int sysctl_tcp_tso_win_divisor __read_mostly = 3;
+ 
+ int sysctl_tcp_mtu_probing __read_mostly = 0;
+ int sysctl_tcp_base_mss __read_mostly = TCP_BASE_MSS;
++int sysctl_tcp_min_snd_mss __read_mostly = TCP_MIN_SND_MSS;
+ 
+ /* By default, RFC2861 behavior.  */
+ int sysctl_tcp_slow_start_after_idle __read_mostly = 1;
+@@ -1259,8 +1260,7 @@ static inline int __tcp_mtu_to_mss(struct sock *sk, int pmtu)
+ 	mss_now -= icsk->icsk_ext_hdr_len;
+ 
+ 	/* Then reserve room for full set of TCP options and 8 bytes of data */
+-	if (mss_now < TCP_MIN_SND_MSS)
+-		mss_now = TCP_MIN_SND_MSS;
++	mss_now = max(mss_now, sysctl_tcp_min_snd_mss);
+ 	return mss_now;
+ }
+ 
+-- 
+cgit v1.1

--- a/target/linux/generic/patches-3.18/900-3-tcp-enforce-tcp_min_snd_mss-in-tcp_mtu_probing.patch
+++ b/target/linux/generic/patches-3.18/900-3-tcp-enforce-tcp_min_snd_mss-in-tcp_mtu_probing.patch
@@ -1,0 +1,44 @@
+From 7ce5a5796ca119c5c6935ea9f4e785f0cb7f39b7 Mon Sep 17 00:00:00 2001
+From: Eric Dumazet <edumazet@google.com>
+Date: Sat, 8 Jun 2019 10:22:49 -0700
+Subject: tcp: enforce tcp_min_snd_mss in tcp_mtu_probing()
+
+commit 967c05aee439e6e5d7d805e195b3a20ef5c433d6 upstream.
+
+If mtu probing is enabled tcp_mtu_probing() could very well end up
+with a too small MSS.
+
+Use the new sysctl tcp_min_snd_mss to make sure MSS search
+is performed in an acceptable range.
+
+CVE-2019-11479 -- tcp mss hardcoded to 48
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Lemon <jonathan.lemon@gmail.com>
+Cc: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+[Salvatore Bonaccorso: Backport for context changes in 4.9.168]
+[bwh: Backported to 3.16: The sysctl is global]
+Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
+---
+ net/ipv4/tcp_timer.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/net/ipv4/tcp_timer.c b/net/ipv4/tcp_timer.c
+index 286227a..a7b930f 100644
+--- a/net/ipv4/tcp_timer.c
++++ b/net/ipv4/tcp_timer.c
+@@ -113,6 +113,7 @@ static void tcp_mtu_probing(struct inet_connection_sock *icsk, struct sock *sk)
+ 			mss = tcp_mtu_to_mss(sk, icsk->icsk_mtup.search_low) >> 1;
+ 			mss = min(sysctl_tcp_base_mss, mss);
+ 			mss = max(mss, 68 - tp->tcp_header_len);
++			mss = max(mss, sysctl_tcp_min_snd_mss);
+ 			icsk->icsk_mtup.search_low = tcp_mss_to_mtu(sk, mss);
+ 			tcp_sync_mss(sk, icsk->icsk_pmtu_cookie);
+ 		}
+-- 
+cgit v1.1

--- a/target/linux/generic/patches-3.18/999-use-nf_ct_helper_log.patch
+++ b/target/linux/generic/patches-3.18/999-use-nf_ct_helper_log.patch
@@ -1,0 +1,47 @@
+From bea588b0281fa3d2ddf365039d1dfddddcbe9aa2 Mon Sep 17 00:00:00 2001
+From: Taehee Yoo <ap420073@gmail.com>
+Date: Mon, 8 Jan 2018 00:10:21 +0900
+Subject: netfilter: nf_nat_snmp_basic: use nf_ct_helper_log
+
+Use nf_ct_helper_log to write log message.
+
+Signed-off-by: Taehee Yoo <ap420073@gmail.com>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/ipv4/netfilter/nf_nat_snmp_basic.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/net/ipv4/netfilter/nf_nat_snmp_basic.c b/net/ipv4/netfilter/nf_nat_snmp_basic.c
+index c8ac57f..7f7d847 100644
+--- a/net/ipv4/netfilter/nf_nat_snmp_basic.c
++++ b/net/ipv4/netfilter/nf_nat_snmp_basic.c
+@@ -1109,7 +1109,7 @@ static int snmp_translate(struct nf_conn *ct, int dir, struct sk_buff *skb)
+ 
+ 	if (!snmp_parse_mangle((unsigned char *)udph + sizeof(struct udphdr),
+ 			       paylen, &map, &udph->check)) {
+-		net_warn_ratelimited("bsalg: parser failed\n");
++		nf_ct_helper_log(skb, ct, "parser failed\n");
+ 		return NF_DROP;
+ 	}
+ 	return NF_ACCEPT;
+@@ -1143,13 +1143,14 @@ static int help(struct sk_buff *skb, unsigned int protoff,
+ 	 * can mess around with the payload.
+ 	 */
+ 	if (ntohs(udph->len) != skb->len - (iph->ihl << 2)) {
+-		net_warn_ratelimited("SNMP: dropping malformed packet src=%pI4 dst=%pI4\n",
+-				     &iph->saddr, &iph->daddr);
+-		 return NF_DROP;
++		nf_ct_helper_log(skb, ct, "dropping malformed packet\n");
++		return NF_DROP;
+ 	}
+ 
+-	if (!skb_make_writable(skb, skb->len))
++	if (!skb_make_writable(skb, skb->len)) {
++		nf_ct_helper_log(skb, ct, "cannot mangle packet");
+ 		return NF_DROP;
++	}
+ 
+ 	spin_lock_bh(&snmp_lock);
+ 	ret = snmp_translate(ct, dir, skb);
+-- 
+cgit v1.1


### PR DESCRIPTION
添加了tcp sack漏洞补丁
添加kmod-cake
让cc可以编译go程序补丁 可以支持到最新的go